### PR TITLE
update py-tgcalls version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 TgCrypto
 git+https://github.com/pyrogram/pyrogram@master
-py-tgcalls==0.8.1b25
+py-tgcalls==0.8.6
 asyncio
 youtube-search-python
 youtube-dl


### PR DESCRIPTION
When deploying our app on Heroku, i just realized that these error come to happen

ERROR: Could not find a version that satisfies the requirement py-tgcalls==0.8.1b25 (from versions: 0.1.0, 0.2.1, 0.3.9, 0.4.9, 0.5.5, 0.6.0, 0.7.4, 0.8.0, 0.8.1, 0.8.2, 0.8.3, 0.8.4, 0.8.5, 0.8.6, 0.9.0b1)
ERROR: No matching distribution found for py-tgcalls==0.8.1b25